### PR TITLE
fix: call `extism_function_free` for functions created with `extism_function_new`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   debug


### PR DESCRIPTION
Fixes #12 

Adds calls to free functions associated with a plugin when the plugin gets cleaned up, or if plugin initialization fails. 

Not sure if this is the most idiomatic way to handle this, so if there's a better way to do this let me know!