### PR TITLE
fix: ensure extism functions are freed

### DIFF
--- a/lib/extism.rb
+++ b/lib/extism.rb
@@ -35,6 +35,16 @@ module Extism
     end
   }
 
+  
+  $FUNCTIONS = {}
+  $FREE_FUNCTION = proc { |ptr|
+    x = $FUNCTIONS[ptr]
+    unless x.nil?
+      LibExtism.extism_function_free(x[:function])
+      $FUNCTIONS.delete(ptr)
+    end
+  }
+
   # Represents a "block" of memory in Extism.
   # This memory is in the communication buffer b/w the
   # guest in the host and technically lives in host memory.

--- a/lib/extism/wasm.rb
+++ b/lib/extism/wasm.rb
@@ -93,6 +93,9 @@ module Extism
       returns = LibExtism.from_int_array(@returns)
       @_pointer = LibExtism.extism_function_new(@name, args, @params.length, returns, @returns.length, c_func, free,
                                                 nil)
+      $FUNCTIONS[object_id] = { function: @_pointer}
+      ObjectSpace.define_finalizer(self, $FREE_FUNCTION)
+      return @_pointer
     end
 
     def c_func


### PR DESCRIPTION
Fixes #12 using a similar approach to how plugins are cleaned up using `ObjectSpace.define_finalizer`