### PR TITLE
fix: get rid of gem build warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     extism (1.0.0)
-      ffi (>= 1.0.0)
+      ffi (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -29,6 +29,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/extism.gemspec
+++ b/extism.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'ffi', '>= 1.0.0'
+  spec.add_dependency 'ffi', '~> 1.0'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Fixes #20 by limiting `ffi` version updates to minor versions only (using the `~>` operator) instead of the unbounded `>=` operator.

### Before
<img width="875" alt="Screenshot 2024-04-05 at 4 30 05 PM" src="https://github.com/extism/ruby-sdk/assets/779389/a49f7cf5-3bc4-4ffb-a18a-20e4e696ac70">

### After
<img width="1017" alt="Screenshot 2024-04-05 at 4 29 45 PM" src="https://github.com/extism/ruby-sdk/assets/779389/564e83d3-7dcb-4a88-9d38-5573ff702b6f">

